### PR TITLE
Add api calls to get and deregister consul services

### DIFF
--- a/consul-haskell.cabal
+++ b/consul-haskell.cabal
@@ -47,7 +47,9 @@ library
     retry,
     stm,
     text,
-    transformers
+    transformers,
+    unordered-containers,
+    vector
   ghc-options:
     -Wall
 

--- a/src/Network/Consul.hs
+++ b/src/Network/Consul.hs
@@ -42,6 +42,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Catch (MonadMask)
 import Control.Monad.Trans.Control
 import Control.Retry
+import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Read as TR

--- a/src/Network/Consul.hs
+++ b/src/Network/Consul.hs
@@ -6,6 +6,7 @@
 module Network.Consul (
     createManagedSession
   , deleteKey
+  , deregisterService
   , destroyManagedSession
   , getKey
   , getKeys
@@ -111,6 +112,9 @@ getServices _client@ConsulClient{..} = I.getServices ccManager (I.hostWithScheme
 {- Agent -}
 getSelf :: MonadIO m => ConsulClient -> m (Maybe Self)
 getSelf _client@ConsulClient{..} = I.getSelf ccManager (I.hostWithScheme _client) ccPort
+
+deregisterService :: MonadIO m => ConsulClient -> Text -> m ()
+deregisterService _client@ConsulClient{..} = I.deregisterService ccManager (I.hostWithScheme _client) ccPort 
 
 registerService :: MonadIO m => ConsulClient -> RegisterService -> Maybe Datacenter -> m Bool
 registerService _client@ConsulClient{..} = I.registerService ccManager (I.hostWithScheme _client) ccPort

--- a/src/Network/Consul.hs
+++ b/src/Network/Consul.hs
@@ -11,6 +11,7 @@ module Network.Consul (
   , getKeys
   , getSelf
   , getService
+  , getServices
   , getServiceHealth
   , getSessionInfo
   , getSequencerForLock
@@ -103,6 +104,9 @@ getServiceHealth _client@ConsulClient{..} = I.getServiceHealth ccManager (I.host
 {- Catalog -}
 getService :: MonadIO m => ConsulClient -> Text -> Maybe Text -> Maybe Datacenter -> m (Maybe [ServiceResult])
 getService _client@ConsulClient{..} = I.getService ccManager (I.hostWithScheme _client) ccPort
+
+getServices :: MonadIO m => ConsulClient -> Maybe Text -> Maybe Datacenter -> m [Text]
+getServices _client@ConsulClient{..} = I.getServices ccManager (I.hostWithScheme _client) ccPort
 
 {- Agent -}
 getSelf :: MonadIO m => ConsulClient -> m (Maybe Self)

--- a/src/Network/Consul.hs
+++ b/src/Network/Consul.hs
@@ -28,7 +28,7 @@ module Network.Consul (
   , registerService
   , runService
   , withManagedSession
-  , withSequencer
+--  , withSequencer
   , withSession
   , module Network.Consul.Types
 ) where
@@ -197,19 +197,20 @@ isValidSequencer client sequencer datacenter = do
   case mkv of
     Just kv -> return $ (maybe False ((sId $ sSession sequencer) ==) $ kvSession kv) && (kvLockIndex kv) == (sLockIndex sequencer)
     Nothing -> return False
-
+{- 
 withSequencer :: (MonadBaseControl IO m, MonadIO m, MonadMask m) => ConsulClient -> Sequencer -> m a -> m a -> Int -> Maybe Datacenter -> m a
 withSequencer client sequencer action lostAction delay dc = do
   mainFunc <- async action
   pulseFunc <- async pulseLock
   waitAny [mainFunc, pulseFunc] >>= return . snd
   where
-    pulseLock = recoverAll (exponentialBackoff 50000 <>  limitRetries 5) $ do
+    pulseLock = recoverAll (exponentialBackoff 50000 <> limitRetries 5) $ do
       liftIO $ threadDelay delay
       valid <- isValidSequencer client sequencer dc
       case valid of
         True -> pulseLock
         False -> lostAction
+-}
 
 {- Helper Functions -}
 {- ManagedSession is a session with an associated TTL healthcheck so the session will be terminated if the client dies. The healthcheck will be automatically updated. -}

--- a/src/Network/Consul/Internal.hs
+++ b/src/Network/Consul/Internal.hs
@@ -324,7 +324,7 @@ getService manager hostname portNumber name tag dc = do
 getServices :: MonadIO m => Manager -> Text -> PortNumber -> Maybe Text -> Maybe Datacenter -> m [Text]
 getServices manager hostname portNumber tag dc = do
     req <- createRequest hostname portNumber "/v1/catalog/services" Nothing Nothing False dc
-    putStrLn "HERE"
+    liftIO $ putStrLn "HERE"
     liftIO $ withResponse req manager $ \ response -> do
         bodyParts <- brConsume $ responseBody response
         return $ parseServices tag $ decode $ BL.fromStrict $ B.concat bodyParts

--- a/src/Network/Consul/Internal.hs
+++ b/src/Network/Consul/Internal.hs
@@ -323,7 +323,7 @@ getService manager hostname portNumber name tag dc = do
 
 getServices :: MonadIO m => Manager -> Text -> PortNumber -> Maybe Text -> Maybe Datacenter -> m [Text]
 getServices manager hostname portNumber tag dc = do
-    req <- createRequest hostname portNumber "/v1/catalog/services" (fmap (T.append "tag=") tag) Nothing False dc
+    req <- createRequest hostname portNumber "/v1/catalog/services" Nothing Nothing False dc
     liftIO $ withResponse req manager $ \ response -> do
         bodyParts <- brConsume $ responseBody response
         return $ parseServices tag $ decode $ BL.fromStrict $ B.concat bodyParts

--- a/src/Network/Consul/Internal.hs
+++ b/src/Network/Consul/Internal.hs
@@ -324,7 +324,6 @@ getService manager hostname portNumber name tag dc = do
 getServices :: MonadIO m => Manager -> Text -> PortNumber -> Maybe Text -> Maybe Datacenter -> m [Text]
 getServices manager hostname portNumber tag dc = do
     req <- createRequest hostname portNumber "/v1/catalog/services" Nothing Nothing False dc
-    liftIO $ putStrLn "HERE"
     liftIO $ withResponse req manager $ \ response -> do
         bodyParts <- brConsume $ responseBody response
         return $ parseServices tag $ decode $ BL.fromStrict $ B.concat bodyParts

--- a/src/Network/Consul/Internal.hs
+++ b/src/Network/Consul/Internal.hs
@@ -324,6 +324,7 @@ getService manager hostname portNumber name tag dc = do
 getServices :: MonadIO m => Manager -> Text -> PortNumber -> Maybe Text -> Maybe Datacenter -> m [Text]
 getServices manager hostname portNumber tag dc = do
     req <- createRequest hostname portNumber "/v1/catalog/services" Nothing Nothing False dc
+    putStrLn "HERE"
     liftIO $ withResponse req manager $ \ response -> do
         bodyParts <- brConsume $ responseBody response
         return $ parseServices tag $ decode $ BL.fromStrict $ B.concat bodyParts


### PR DESCRIPTION
I've been using this library to manage services in consul, and to do that effectively I needed to extend the api to get the list of services currently registered in consul and to deregister a service.
