### PR TITLE
Add api calls to get and deregister consul services

### DIFF
--- a/consul-haskell.cabal
+++ b/consul-haskell.cabal
@@ -47,7 +47,9 @@ library
     retry,
     stm,
     text,
-    transformers
+    transformers,
+    unordered-containers,
+    vector
   ghc-options:
     -Wall
 

--- a/src/Network/Consul.hs
+++ b/src/Network/Consul.hs
@@ -11,6 +11,7 @@ module Network.Consul (
   , getKeys
   , getSelf
   , getService
+  , getServices
   , getServiceHealth
   , getSessionInfo
   , getSequencerForLock
@@ -102,6 +103,9 @@ getServiceHealth _client@ConsulClient{..} = I.getServiceHealth ccManager (I.host
 {- Catalog -}
 getService :: MonadIO m => ConsulClient -> Text -> Maybe Text -> Maybe Datacenter -> m (Maybe [ServiceResult])
 getService _client@ConsulClient{..} = I.getService ccManager (I.hostWithScheme _client) ccPort
+
+getServices :: MonadIO m => ConsulClient -> Maybe Text -> Maybe Datacenter -> m [Text]
+getServices _client@ConsulClient{..} = I.getServices ccManager (I.hostWithScheme _client) ccPort
 
 {- Agent -}
 getSelf :: MonadIO m => ConsulClient -> m (Maybe Self)

--- a/src/Network/Consul.hs
+++ b/src/Network/Consul.hs
@@ -7,6 +7,7 @@ module Network.Consul (
     createSession
   , deleteKey
   , destroySession
+  , deregisterService
   , getKey
   , getKeys
   , getSelf
@@ -110,6 +111,9 @@ getServices _client@ConsulClient{..} = I.getServices ccManager (I.hostWithScheme
 {- Agent -}
 getSelf :: MonadIO m => ConsulClient -> m (Maybe Self)
 getSelf _client@ConsulClient{..} = I.getSelf ccManager (I.hostWithScheme _client) ccPort
+
+deregisterService :: MonadIO m => ConsulClient -> Text -> m ()
+deregisterService _client@ConsulClient{..} = I.deregisterService ccManager (I.hostWithScheme _client) ccPort 
 
 registerService :: MonadIO m => ConsulClient -> RegisterService -> Maybe Datacenter -> m Bool
 registerService _client@ConsulClient{..} = I.registerService ccManager (I.hostWithScheme _client) ccPort

--- a/src/Network/Consul.hs
+++ b/src/Network/Consul.hs
@@ -27,7 +27,6 @@ module Network.Consul (
   , registerService
   , renewSession
   , runService
-  , withSequencer
   , withSession
   , module Network.Consul.Types
 ) where
@@ -189,56 +188,10 @@ withSequencer client sequencer action lostAction delay dc =
   withAsync action $ \ mainAsync -> withAsync pulseLock $ \ pulseAsync -> do
     waitAnyCancel [mainAsync, pulseAsync] >>= return . snd
   where
-<<<<<<< 901763baff185f3be18054646531bf88161310c5
     pulseLock = recoverAll (exponentialBackoff 50000 <>  limitRetries 5) $ \ _ -> do
-=======
-    pulseLock = recoverAll (exponentialBackoff 50000 <> limitRetries 5) $ do
->>>>>>> Remove withSequencer for now
       liftIO $ threadDelay delay
       valid <- isValidSequencer client sequencer dc
       case valid of
         True -> pulseLock
         False -> lostAction
-<<<<<<< 901763baff185f3be18054646531bf88161310c5
-=======
 -}
-
-{- Helper Functions -}
-{- ManagedSession is a session with an associated TTL healthcheck so the session will be terminated if the client dies. The healthcheck will be automatically updated. -}
-data ManagedSession = ManagedSession{
-  msSession :: Session,
-  msThreadId :: ThreadId
-}
-
-withManagedSession :: (MonadBaseControl IO m, MonadIO m) => ConsulClient -> Text -> (Session -> m ()) -> m () -> m ()
-withManagedSession client ttl action lostAction = do
-  x <- createManagedSession client Nothing ttl
-  case x of
-    Just s -> withSession client (msSession s) action lostAction >> destroyManagedSession client s
-    Nothing -> lostAction
-
-createManagedSession :: MonadIO m => ConsulClient -> Maybe Text -> Text -> m (Maybe ManagedSession)
-createManagedSession _client@ConsulClient{..} name ttl = do
-  let r = SessionRequest Nothing name Nothing [] (Just Release) (Just ttl)
-  s <- I.createSession ccManager (I.hostWithScheme _client) ccPort r Nothing
-  mapM f s
-  where
-    f x = do
-      tid <- liftIO $ forkIO $ runThread x
-      return $ ManagedSession x tid
-
-    saneTtl = let Right (x,_) = TR.decimal $ T.filter (/= 's') ttl in x
-
-    runThread :: Session -> IO ()
-    runThread s = do
-      threadDelay $ (saneTtl - (saneTtl - 10)) * 1000000
-      x <- I.renewSession ccManager (I.hostWithScheme _client) ccPort s Nothing
-      case x of
-        True -> runThread s
-        False -> return ()
-
-destroyManagedSession :: MonadIO m => ConsulClient -> ManagedSession -> m ()
-destroyManagedSession _client@ConsulClient{..} (ManagedSession session tid) = do
-  liftIO $ killThread tid
-  I.destroySession ccManager (I.hostWithScheme _client) ccPort session Nothing
->>>>>>> Remove withSequencer for now

--- a/src/Network/Consul/Internal.hs
+++ b/src/Network/Consul/Internal.hs
@@ -328,7 +328,7 @@ getService manager hostname portNumber name tag dc = do
 getServices :: MonadIO m => Manager -> Text -> PortNumber -> Maybe Text -> Maybe Datacenter -> m [Text]
 getServices manager hostname portNumber tag dc = do
     req <- createRequest hostname portNumber "/v1/catalog/services" Nothing Nothing False dc
-    putStrLn "HERE"
+    liftIO $ putStrLn "HERE"
     liftIO $ withResponse req manager $ \ response -> do
         bodyParts <- brConsume $ responseBody response
         return $ parseServices tag $ decode $ BL.fromStrict $ B.concat bodyParts

--- a/src/Network/Consul/Internal.hs
+++ b/src/Network/Consul/Internal.hs
@@ -328,6 +328,7 @@ getService manager hostname portNumber name tag dc = do
 getServices :: MonadIO m => Manager -> Text -> PortNumber -> Maybe Text -> Maybe Datacenter -> m [Text]
 getServices manager hostname portNumber tag dc = do
     req <- createRequest hostname portNumber "/v1/catalog/services" Nothing Nothing False dc
+    putStrLn "HERE"
     liftIO $ withResponse req manager $ \ response -> do
         bodyParts <- brConsume $ responseBody response
         return $ parseServices tag $ decode $ BL.fromStrict $ B.concat bodyParts

--- a/src/Network/Consul/Internal.hs
+++ b/src/Network/Consul/Internal.hs
@@ -328,7 +328,6 @@ getService manager hostname portNumber name tag dc = do
 getServices :: MonadIO m => Manager -> Text -> PortNumber -> Maybe Text -> Maybe Datacenter -> m [Text]
 getServices manager hostname portNumber tag dc = do
     req <- createRequest hostname portNumber "/v1/catalog/services" Nothing Nothing False dc
-    liftIO $ putStrLn "HERE"
     liftIO $ withResponse req manager $ \ response -> do
         bodyParts <- brConsume $ responseBody response
         return $ parseServices tag $ decode $ BL.fromStrict $ B.concat bodyParts

--- a/src/Network/Consul/Internal.hs
+++ b/src/Network/Consul/Internal.hs
@@ -327,7 +327,7 @@ getService manager hostname portNumber name tag dc = do
 
 getServices :: MonadIO m => Manager -> Text -> PortNumber -> Maybe Text -> Maybe Datacenter -> m [Text]
 getServices manager hostname portNumber tag dc = do
-    req <- createRequest hostname portNumber "/v1/catalog/services" (fmap (T.append "tag=") tag) Nothing False dc
+    req <- createRequest hostname portNumber "/v1/catalog/services" Nothing Nothing False dc
     liftIO $ withResponse req manager $ \ response -> do
         bodyParts <- brConsume $ responseBody response
         return $ parseServices tag $ decode $ BL.fromStrict $ B.concat bodyParts

--- a/src/Network/Consul/Internal.hs
+++ b/src/Network/Consul/Internal.hs
@@ -37,15 +37,18 @@ module Network.Consul.Internal (
   --Catalog
   , getDatacenters
   , getService
+  , getServices
   ) where
 
 import Control.Monad.IO.Class
-import Data.Aeson (decode,encode)
+import Data.Aeson (Value(..), decode,encode)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 --import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.HashMap.Strict as H
 import Data.Maybe
+import qualified Data.Vector as V
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
@@ -321,3 +324,18 @@ getService manager hostname portNumber name tag dc = do
   liftIO $ withResponse req manager $ \ response -> do
     bodyParts <- brConsume $ responseBody response
     return $ decode $ BL.fromStrict $ B.concat bodyParts
+
+getServices :: MonadIO m => Manager -> Text -> PortNumber -> Maybe Text -> Maybe Datacenter -> m [Text]
+getServices manager hostname portNumber tag dc = do
+    req <- createRequest hostname portNumber "/v1/catalog/services" (fmap (T.append "tag=") tag) Nothing False dc
+    liftIO $ withResponse req manager $ \ response -> do
+        bodyParts <- brConsume $ responseBody response
+        return $ parseServices tag $ decode $ BL.fromStrict $ B.concat bodyParts
+  where
+    parseServices t (Just (Object v)) = filterTags t $ H.toList v
+    parseServices _   _               = []
+    filterTags :: Maybe Text -> [(Text, Value)] -> [Text]
+    filterTags (Just t)               = map fst . filter (\ (_, (Array v)) -> (String t) `V.elem` v)
+    filterTags Nothing                = map fst
+
+


### PR DESCRIPTION
I've been using this library to manage services in consul, and to do that effectively I needed to extend the api to get the list of services currently registered in consul and to deregister a service.
