### PR TITLE
Fix GHC 8.0.2 build

### DIFF
--- a/src/Network/Consul/Types.hs
+++ b/src/Network/Consul/Types.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+#if __GLASGOW_HASKELL__ < 710
+{-# LANGUAGE OverlappingInstances #-}
+#endif
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Network.Consul.Types (
   Check(..),
@@ -292,7 +295,11 @@ instance ToJSON HealthCheck where
 instance ToJSON SessionRequest where
   toJSON (SessionRequest lockDelay name node checks behavior ttl) = object["LockDelay" .= lockDelay, "Name" .= name, "Node" .= (fmap nNode node), "Checks" .= checks, "Behavior" .= behavior, "TTL" .= ttl]
 
-instance ToJSON (Either (Text,Text) Text) where
+instance
+#if __GLASGOW_HASKELL__ >= 710
+    {-# OVERLAPPING #-}
+#endif
+    ToJSON (Either (Text,Text) Text) where
   toJSON (Left (script,interval)) = object ["Script" .= script, "Interval" .= interval]
   toJSON (Right ttl) = object ["TTL" .= ttl]
 


### PR DESCRIPTION
This library fails to build with GHC 8.0.2 because it mistakenly doesn't annotate its overlapping instances with `OVERLAPPING` annotations (8.0.2 is more strict about this than previous versions, see https://ghc.haskell.org/trac/ghc/ticket/12881). Luckily, it's easy to fix.