### PR TITLE
.github/workflows/ci: attempt to turn consul-version into a matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,13 @@ on:
 
 jobs:
   stack:
-    name: stack / ghc ${{ matrix.ghc }}
+    name: stack ${{ matrix.stack }} / ghc ${{ matrix.ghc }} / consul ${{ matrix.consul-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         stack: ["2.3.1"]
         ghc: ["8.8.3"]
+        consul-version: ["1.3.1", "1.4.5", "1.5.3", "1.6.10", "1.7.11", "1.8.7", "1.9.0"]
 
     steps:
     - uses: actions/checkout@v2
@@ -37,12 +38,10 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       run: |
-        sudo apt update
-        sudo apt install unzip
-        wget -q 'https://releases.hashicorp.com/consul/1.9.0/consul_1.9.0_linux_amd64.zip'
-        unzip "consul_1.9.0_linux_amd64.zip"
-        sudo mkdir -p ~/.local/bin/ && sudo mv consul ~/.local/bin/ && sudo chmod +x ~/.local/bin/consul
-        
+        wget -q 'https://releases.hashicorp.com/consul/${{ matrix.consul-version }}/consul_${{ matrix.consul-version }}_linux_amd64.zip'
+        unzip consul_${{ matrix.consul-version }}_linux_amd64.zip
+        sudo mkdir -p ~/.local/bin/ && sudo mv consul ~/.local/bin/consul-${{ matrix.consul-version }} && sudo chmod +x ~/.local/bin/consul-${{ matrix.consul-version }} && sudo ln -sf  ~/.local/bin/consul-${{ matrix.consul-version }}  ~/.local/bin/consul
+
     - name: Build
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true


### PR DESCRIPTION
By running different versions of consul at the same time, we can more effectively see which versions of consul our library actually works correctly with.