### PR TITLE
tests: retry createSession to deal with Node registration race condition

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -235,8 +235,23 @@ testCreateSession = testCase "testCreateSession" $ do
   result <- createSession client req Nothing
   case result of
     Just _ -> return ()
-    Nothing -> assertFailure "testCreateSession: No session was created"
+    Nothing -> do
+      -- pause
+      threadDelay fiveSecondMicros
+      -- retry
+      result <- createSession client req Nothing
+      case result of
+        Just _ -> return ()
+        Nothing -> assertFailure "testCreateSession: No session was created"
 
+
+fiveSecondMicros :: Int
+fiveSecondMicros = oneSecondMicros * 5
+
+oneSecondMicros :: Int
+oneSecondMicros = 1 * 1000 * 1000
+
+--
 testGetSessionInfo :: TestTree
 testGetSessionInfo = testCase "testGetSessionInfo" $ do
   client@ConsulClient{..} <- newClient


### PR DESCRIPTION
Tests would often (10% of the time or so) fail with an error like:

> testCreateSession:               2020/12/13 23:33:40 [ERR] http: Request PUT /v1/session/create, error: Missing node registration from=127.0.0.1:45790

When the agent starts up, it registers the agent's node in the consul catalog.
While the agent may be "ready", the node isn't always registered, and these
session tests would fail if that node was not yet ready. This would happen
because the Session API requires the Node referenced in the API request to be
a node registered in the Consul catalog, so the node must be registered before
using the Session API.