### PR TITLE
.github/ci: bump consul version 1.9.0 to 1.9.4 add 1.10.0-alpha, improve CI cache, fix CI installing consul

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,28 +27,35 @@ jobs:
           - "1.9.4"
           - "1.10.0-alpha"
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Git Repo
+      uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1
-      name: Setup Haskell Stack
+    - name: Setup Haskell Stack
+      uses: actions/setup-haskell@v1.1
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       with:
         ghc-version: ${{ matrix.ghc }}
         stack-version: ${{ matrix.stack }}
 
-    - uses: actions/cache@v2
-      name: Cache ~/.stack
+    - name: Cache ~/.stack
+      uses: actions/cache@v2
       with:
         path: ~/.stack
-        key: ${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-consul-${{ matrix.consul-version }}-stack-work
+        key: ${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-dot-stack-root
 
-    - uses: actions/cache@v2
-      name: Cache .stack-work
+    - name: Cache .stack-work
+      uses: actions/cache@v2
       with:
         path: .stack-work
-        key: ${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-consul-${{ matrix.consul-version }}-stack-work
+        key: ${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-dot-stack-work
+
+    - name: Cache Consul Executables
+      uses: actions/cache@v2
+      with:
+        path: /opt/consul
+        key: ${{ runner.os }}-stack-${{ matrix.stack }}-ghc-${{ matrix.ghc }}-consul-${{ matrix.consul-version }}
 
     - name: Install Consul
       env:
@@ -57,17 +64,18 @@ jobs:
         sudo make install-consul VERSION=${{ matrix.consul-version }}
         sudo make symlink-consul VERSION=${{ matrix.consul-version }}
 
-    - name: Build
+    - name: Stack Build
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       run: |
-        PATH=~/.local/bin/:$PATH stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+        make build
 
-    - name: Test
+    - name: Stack Test
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       run: |
-        PATH=~/.local/bin/:$PATH stack test --system-ghc
+        make test
+
   # Inspired by:
   # https://nix.dev/tutorials/continuous-integration-github-actions.html
   nix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
           - "1.6.10"
           - "1.7.11"
           - "1.8.7"
-          - "1.9.0"
+          - "1.9.4"
+          - "1.10.0-alpha"
     steps:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
-install-consul: require-VERSION
+INSTALL_TO := /opt/consul
+
+install-consul: require-VERSION require-INSTALL_TO
 	wget -q 'https://releases.hashicorp.com/consul/${VERSION}/consul_${VERSION}_linux_amd64.zip'
 	unzip consul_${VERSION}_linux_amd64.zip
-	mkdir -p ~/.local/bin/
-	mv consul ~/.local/bin/consul-${VERSION}
-	chmod +x ~/.local/bin/consul-${VERSION}
-	echo "installed consul to ~/.local/bin/consul-${VERSION}"
+	mkdir -p ${INSTALL_TO}
+	mv consul ${INSTALL_TO}/consul-${VERSION}
+	chmod +x ${INSTALL_TO}/consul-${VERSION}
+	echo "installed consul to ${INSTALL_TO}/consul-${VERSION}"
 
-symlink-consul: require-VERSION
-	sudo ln -sf  ~/.local/bin/consul-${VERSION}  ~/.local/bin/consul
+symlink-consul: require-VERSION require-INSTALL_TO
+	sudo ln -sf  ${INSTALL_TO}/consul-${VERSION}  ${INSTALL_TO}/consul
+
+build: require-INSTALL_TO
+	PATH=${INSTALL_TO}/:${PATH} stack build --system-ghc --no-run-tests --no-run-benchmarks
+
+test: require-INSTALL_TO
+	PATH=${INSTALL_TO}/:${PATH} stack test --system-ghc --bench
 
 require-%:
 	if [ "${${*}}" = "" ]; then \


### PR DESCRIPTION
This includes 3 main changes:
* .github/ci: bump consul version 1.9.0 to 1.9.4 add 1.10.0-alpha (test against latest consul)
* improve CI cache (faster builds)
* fix CI installing consul (CI works again!)