### PR TITLE
Removing parse error for haddock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,12 @@ jobs:
       run: |
         make test
 
+    - name: Stack Doc
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      run: |
+        make doc
+
   # Inspired by:
   # https://nix.dev/tutorials/continuous-integration-github-actions.html
   nix:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ build: require-INSTALL_TO
 test: require-INSTALL_TO
 	PATH=${INSTALL_TO}/:${PATH} stack test --system-ghc --bench
 
+doc: require-INSTALL_TO
+	PATH=${INSTALL_TO}/:${PATH} stack build --haddock --haddock-deps --haddock-internal --haddock-hyperlink-source
+
 require-%:
 	if [ "${${*}}" = "" ]; then \
 		echo "ERROR: Environment variable not set: \"$*\""; \

--- a/src/Network/Consul.hs
+++ b/src/Network/Consul.hs
@@ -76,8 +76,8 @@ initializeConsulClient hostname port man = do
                         Just x -> return x
                         Nothing -> newTlsManager
   return $ ConsulClient manager hostname port False Nothing
-                                                 -- ^ we omit a Datacenter here for brevity
-                                                 --   it's still allowed via record updates 
+                                                 -- we omit a Datacenter here for brevity
+                                                 -- it's still allowed via record updates
 
 
 initializeTlsConsulClient :: MonadIO m => Text -> PortNumber -> Maybe Manager -> m ConsulClient


### PR DESCRIPTION
I was generating local haddock, and I found that it failed on '^' symbol
in this comment. So, I removed it.

If you want to test haddock generation, use:

```
stack build --haddock --haddock-deps --haddock-internal --haddock-hyperlink-source
```