### PR TITLE
add empty source files for client API functions

### DIFF
--- a/consul-haskell.cabal
+++ b/consul-haskell.cabal
@@ -29,12 +29,23 @@ library
     Import
     Network.Consul
     -- Consul Client API
+    Network.Consul.Client.Acl
     Network.Consul.Client.Agent
     Network.Consul.Client.Catalog
+    Network.Consul.Client.Config
+    Network.Consul.Client.Connect
+    Network.Consul.Client.Events
     Network.Consul.Client.Health
     Network.Consul.Client.Init
     Network.Consul.Client.KVStore
+    Network.Consul.Client.Namespaces
+    Network.Consul.Client.Operator
+    Network.Consul.Client.PreparedQueries
     Network.Consul.Client.Session
+    Network.Consul.Client.Snapshots
+    Network.Consul.Client.Status
+    Network.Consul.Client.Transactions
+ -- Network.Consul.Client.
 
     -- higher level stuff
     Network.Consul.Misc

--- a/src/Network/Consul.hs
+++ b/src/Network/Consul.hs
@@ -53,12 +53,22 @@ import Import
 
 import Network.Consul.Types
 -- Consul Client APIs
+import Network.Consul.Client.Acl
 import Network.Consul.Client.Agent
 import Network.Consul.Client.Catalog
+import Network.Consul.Client.Config
+import Network.Consul.Client.Connect
+import Network.Consul.Client.Events
 import Network.Consul.Client.Health
 import Network.Consul.Client.Init
 import Network.Consul.Client.KVStore
+import Network.Consul.Client.Namespaces
+import Network.Consul.Client.Operator
+import Network.Consul.Client.PreparedQueries
 import Network.Consul.Client.Session
+import Network.Consul.Client.Snapshots
+import Network.Consul.Client.Status
+import Network.Consul.Client.Transactions
 
 import Network.Consul.Sequencer
 import Network.Consul.Misc

--- a/src/Network/Consul/Client/Acl.hs
+++ b/src/Network/Consul/Client/Acl.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | TODO: document module
+module Network.Consul.Client.Acl
+  ( 
+  ) where
+
+

--- a/src/Network/Consul/Client/Config.hs
+++ b/src/Network/Consul/Client/Config.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | TODO: document module
+module Network.Consul.Client.Config
+  ( 
+  ) where
+
+

--- a/src/Network/Consul/Client/Connect.hs
+++ b/src/Network/Consul/Client/Connect.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | TODO: document module
+module Network.Consul.Client.Connect
+  ( 
+  ) where
+
+

--- a/src/Network/Consul/Client/Coordinates.hs
+++ b/src/Network/Consul/Client/Coordinates.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | TODO: document module
+module Network.Consul.Client.Acl
+  ( 
+  ) where
+
+

--- a/src/Network/Consul/Client/Events.hs
+++ b/src/Network/Consul/Client/Events.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | TODO: document module
+module Network.Consul.Client.Events
+  ( 
+  ) where
+
+

--- a/src/Network/Consul/Client/Namespaces.hs
+++ b/src/Network/Consul/Client/Namespaces.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | TODO: document module
+module Network.Consul.Client.Namespaces
+  ( 
+  ) where
+
+

--- a/src/Network/Consul/Client/Operator.hs
+++ b/src/Network/Consul/Client/Operator.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | TODO: document module
+module Network.Consul.Client.Operator
+  ( 
+  ) where
+
+

--- a/src/Network/Consul/Client/PreparedQueries.hs
+++ b/src/Network/Consul/Client/PreparedQueries.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | TODO: document module
+module Network.Consul.Client.PreparedQueries
+  ( 
+  ) where
+
+

--- a/src/Network/Consul/Client/Snapshots.hs
+++ b/src/Network/Consul/Client/Snapshots.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | TODO: document module
+module Network.Consul.Client.Snapshots
+  ( 
+  ) where
+
+

--- a/src/Network/Consul/Client/Status.hs
+++ b/src/Network/Consul/Client/Status.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | TODO: document module
+module Network.Consul.Client.Status
+  ( 
+  ) where
+
+

--- a/src/Network/Consul/Client/Transactions.hs
+++ b/src/Network/Consul/Client/Transactions.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | TODO: document module
+module Network.Consul.Client.Transactions
+  ( 
+  ) where
+
+

--- a/src/Network/Consul/Sequencer.hs
+++ b/src/Network/Consul/Sequencer.hs
@@ -10,37 +10,13 @@ module Network.Consul.Sequencer
   , withSequencer
   ) where
 
-import Control.Concurrent hiding (killThread)
-import Control.Monad (forever)
-import Control.Monad.IO.Class
-import Control.Monad.Catch (MonadMask)
-import Control.Retry
-import Data.Aeson (Value(..), decode,encode)
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.HashMap.Strict as H
-import Data.Maybe (catMaybes, isJust, listToMaybe)
-import Data.Monoid ((<>))
-import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Read as TR
-import Data.Word
-import qualified Data.Vector as V
-import qualified Network.Consul.Internal as I
-import Network.Consul.Types
-import Network.HTTP.Client -- (method, Manager, responseBody)
-import Network.HTTP.Client.TLS (newTlsManager, newTlsManagerWith, tlsManagerSettings)
-import Network.HTTP.Types
-import Network.Socket (PortNumber)
-import UnliftIO (MonadUnliftIO, async, cancel, finally, wait, waitAnyCancel, withAsync)
+import Import
 
-import Network.Consul.Internal
 import Network.Consul.Client.KVStore
 
 -- | TODO: Document
 getSequencerForLock :: MonadIO m => ConsulClient -> Text -> Session -> m (Maybe Sequencer)
 getSequencerForLock client key session = do
-  let dc = ccDatacenter client
   kv <- getKey client key Nothing (Just Consistent)
   case kv of
     Just k -> do


### PR DESCRIPTION
The nice thing is that with the imports in Network.Consul, the empty
source files have a GHC warning pointed at them.