### PR TITLE
Placeholders for missing API functions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.6.3
+
+Scope out placeholders for WIP client API functions, see
+[PR#60](https://github.com/alphaHeavy/consul-haskell/pull/60) for more info.
+
 ## v0.6.2
 
 Code shuffle!

--- a/consul-haskell.cabal
+++ b/consul-haskell.cabal
@@ -1,5 +1,5 @@
 name:                consul-haskell
-version:             0.6.2
+version:             0.6.3
 synopsis:            A consul client for Haskell
 description:
   A consul client for Haskell

--- a/src/Network/Consul/Client/Acl.hs
+++ b/src/Network/Consul/Client/Acl.hs
@@ -8,4 +8,4 @@ module Network.Consul.Client.Acl
   ( 
   ) where
 
-
+import Import

--- a/src/Network/Consul/Client/Config.hs
+++ b/src/Network/Consul/Client/Config.hs
@@ -4,8 +4,18 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | TODO: document module
+-- https://www.consul.io/api-docs/config
 module Network.Consul.Client.Config
-  ( 
+  ( putConfig
+  , getConfig
   ) where
 
 import Import
+
+-- | Apply (Put) Configuration
+putConfig :: MonadIO m => ConsulClient -> m ()
+putConfig = undefined
+
+-- | Get Configuration
+getConfig :: MonadIO m => ConsulClient -> m ()
+getConfig = undefined

--- a/src/Network/Consul/Client/Config.hs
+++ b/src/Network/Consul/Client/Config.hs
@@ -8,4 +8,4 @@ module Network.Consul.Client.Config
   ( 
   ) where
 
-
+import Import

--- a/src/Network/Consul/Client/Connect.hs
+++ b/src/Network/Consul/Client/Connect.hs
@@ -8,4 +8,4 @@ module Network.Consul.Client.Connect
   ( 
   ) where
 
-
+import Import

--- a/src/Network/Consul/Client/Coordinates.hs
+++ b/src/Network/Consul/Client/Coordinates.hs
@@ -4,8 +4,33 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | TODO: document module
+-- https://www.consul.io/api-docs/coordinate
 module Network.Consul.Client.Acl
-  ( 
+  ( getNodeLANCoordinates
+  , listNodeLANCoordinates
+  , listServerWANCoordinates
+  , updateNodeLANCoordinates
   ) where
 
 import Import
+
+-- | Read LAN Coordinates for a node
+getNodeLANCoordinates :: MonadIO m => ConsulClient -> m ()
+getNodeLANCoordinates = undefined
+
+-- | Read LAN Coordinates for all nodes
+listNodeLANCoordinates :: MonadIO m => ConsulClient -> m ()
+listNodeLANCoordinates = undefined
+
+-- | Read WAN Coordinates
+-- > This endpoint returns the WAN network coordinates for all Consul servers,
+-- > organized by datacenters. It serves data out of the server's local Serf data,
+-- > so its results may vary as requests are handled by different servers in the
+-- > cluster.
+listServerWANCoordinates :: MonadIO m => ConsulClient -> m ()
+listServerWANCoordinates = undefined
+
+-- | Update LAN Coordinates for a node
+updateNodeLANCoordinates :: MonadIO m => ConsulClient -> m ()
+updateNodeLANCoordinates = undefined
+

--- a/src/Network/Consul/Client/Coordinates.hs
+++ b/src/Network/Consul/Client/Coordinates.hs
@@ -8,4 +8,4 @@ module Network.Consul.Client.Acl
   ( 
   ) where
 
-
+import Import

--- a/src/Network/Consul/Client/Events.hs
+++ b/src/Network/Consul/Client/Events.hs
@@ -5,7 +5,17 @@
 
 -- | TODO: document module
 module Network.Consul.Client.Events
-  ( 
+  ( createEvent
+  , listEvents
   ) where
 
+import Import
 
+-- | TODO: Document
+createEvent :: MonadIO m => ConsulClient -> SessionRequest -> m ()
+createEvent = undefined
+
+
+-- | TODO: Document
+listEvents :: MonadIO m => ConsulClient -> SessionRequest -> m ()
+listEvents = undefined

--- a/src/Network/Consul/Client/Namespaces.hs
+++ b/src/Network/Consul/Client/Namespaces.hs
@@ -8,4 +8,4 @@ module Network.Consul.Client.Namespaces
   ( 
   ) where
 
-
+import Import

--- a/src/Network/Consul/Client/Namespaces.hs
+++ b/src/Network/Consul/Client/Namespaces.hs
@@ -4,8 +4,34 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | TODO: document module
+-- https://www.consul.io/api-docs/namespaces
 module Network.Consul.Client.Namespaces
-  ( 
+  ( createNamespace
+  , deleteNamespace
+  , getNamespace     -- readNamespace
+  , listNamespaces
+  , updateNamespace
   ) where
 
 import Import
+
+-- | TODO: Document
+createNamespace :: MonadIO m => ConsulClient -> SessionRequest -> m ()
+createNamespace = undefined
+
+-- | TODO: Document
+deleteNamespace :: MonadIO m => ConsulClient -> SessionRequest -> m ()
+deleteNamespace = undefined
+
+-- | TODO: Document
+getNamespace :: MonadIO m => ConsulClient -> SessionRequest -> m ()
+getNamespace = undefined
+
+-- | TODO: Document
+listNamespaces :: MonadIO m => ConsulClient -> SessionRequest -> m ()
+listNamespaces = undefined
+
+-- | TODO: Document
+updateNamespace :: MonadIO m => ConsulClient -> SessionRequest -> m ()
+updateNamespace = undefined
+ 

--- a/src/Network/Consul/Client/Operator.hs
+++ b/src/Network/Consul/Client/Operator.hs
@@ -8,4 +8,4 @@ module Network.Consul.Client.Operator
   ( 
   ) where
 
-
+import Import

--- a/src/Network/Consul/Client/PreparedQueries.hs
+++ b/src/Network/Consul/Client/PreparedQueries.hs
@@ -8,4 +8,4 @@ module Network.Consul.Client.PreparedQueries
   ( 
   ) where
 
-
+import Import

--- a/src/Network/Consul/Client/PreparedQueries.hs
+++ b/src/Network/Consul/Client/PreparedQueries.hs
@@ -4,8 +4,43 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | TODO: document module
+-- https://www.consul.io/api-docs/query
 module Network.Consul.Client.PreparedQueries
-  ( 
+  ( createQuery
+  , deleteQuery
+  , executeQuery
+  , explainQuery
+  , getQuery
+  , listQueries
+  , updateQuery
   ) where
 
 import Import
+
+-- | TODO: Document
+createQuery :: MonadIO m => ConsulClient -> SessionRequest -> m ()
+createQuery = undefined
+
+-- | TODO: Document
+deleteQuery :: MonadIO m => ConsulClient -> SessionRequest -> m ()
+deleteQuery = undefined
+
+-- | TODO: Document
+executeQuery :: MonadIO m => ConsulClient -> m ()
+executeQuery = undefined
+
+-- | TODO: Document
+explainQuery :: MonadIO m => ConsulClient -> m ()
+explainQuery = undefined
+
+-- | TODO: Document
+getQuery :: MonadIO m => ConsulClient -> m ()
+getQuery = undefined
+
+-- | TODO: Document
+listQueries :: MonadIO m => ConsulClient -> m ()
+listQueries = undefined
+
+-- | TODO: Document
+updateQuery :: MonadIO m => ConsulClient -> m ()
+updateQuery = undefined

--- a/src/Network/Consul/Client/Snapshots.hs
+++ b/src/Network/Consul/Client/Snapshots.hs
@@ -8,4 +8,4 @@ module Network.Consul.Client.Snapshots
   ( 
   ) where
 
-
+import Import

--- a/src/Network/Consul/Client/Snapshots.hs
+++ b/src/Network/Consul/Client/Snapshots.hs
@@ -4,8 +4,18 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | TODO: document module
+-- https://www.consul.io/api-docs/snapshot
 module Network.Consul.Client.Snapshots
-  ( 
+  ( createSnapshot -- generateSnapshot
+  , restoreSnapshot
   ) where
 
 import Import
+
+-- | TODO: Document
+createSnapshot :: MonadIO m => ConsulClient -> m ()
+createSnapshot = undefined
+
+-- | TODO: Document
+restoreSnapshot :: MonadIO m => ConsulClient -> m ()
+restoreSnapshot = undefined

--- a/src/Network/Consul/Client/Status.hs
+++ b/src/Network/Consul/Client/Status.hs
@@ -8,4 +8,4 @@ module Network.Consul.Client.Status
   ( 
   ) where
 
-
+import Import

--- a/src/Network/Consul/Client/Status.hs
+++ b/src/Network/Consul/Client/Status.hs
@@ -5,7 +5,18 @@
 
 -- | TODO: document module
 module Network.Consul.Client.Status
-  ( 
+  ( getRaftPeer
+  , listRaftPeers
   ) where
 
 import Import
+
+-- | Get Raft Peer
+--getRaftPeer :: MonadIO m => ConsulClient -> Maybe Datacenter -> m (Maybe Peer)
+getRaftPeer :: MonadIO m => ConsulClient -> m ()
+getRaftPeer = undefined
+
+-- | List Raft Peers
+--listRaftPeers :: MonadIO m => ConsulClient -> Maybe Datacenter -> m ([Peer])
+listRaftPeers :: MonadIO m => ConsulClient -> m ()
+listRaftPeers = undefined

--- a/src/Network/Consul/Client/Transactions.hs
+++ b/src/Network/Consul/Client/Transactions.hs
@@ -8,4 +8,4 @@ module Network.Consul.Client.Transactions
   ( 
   ) where
 
-
+import Import

--- a/src/Network/Consul/Client/Transactions.hs
+++ b/src/Network/Consul/Client/Transactions.hs
@@ -4,8 +4,14 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | TODO: document module
+-- https://www.consul.io/api-docs/txn
 module Network.Consul.Client.Transactions
-  ( 
+  ( createTransaction 
   ) where
 
 import Import
+
+-- | Create Transaction
+--createTransaction :: MonadIO m => ConsulClient -> m (Maybe Transaction)
+createTransaction :: MonadIO m => ConsulClient -> m ()
+createTransaction = undefined


### PR DESCRIPTION
This skips Acl, Operator, and Connect, as those APIs are more work to implement.