### PR TITLE
Use package crypton-connection

### DIFF
--- a/consul-haskell.cabal
+++ b/consul-haskell.cabal
@@ -59,7 +59,7 @@ library
     , base >=4.10 && <5
     , base64-bytestring
     , bytestring
-    , connection
+    , crypton-connection
     , either
     , exceptions
     , http-client


### PR DESCRIPTION
Package `connection` is no longer maintained, `crypton-connection` is a maintained fork of this. This update enables building with the latest version of package `tls` (*2.0.0* against *1.6.0*).